### PR TITLE
add observable creation-like matchers

### DIFF
--- a/Example/ExampleTests/ExampleTests.swift
+++ b/Example/ExampleTests/ExampleTests.swift
@@ -116,6 +116,12 @@ class ExampleTests: XCTestCase {
         scheduler.start()
         assert(source).empty()
     }
+    func testJust() {
+        let source = scheduler.record(source: viewModel.elements)
+        scheduler.bind([next(10, "alpha"), completed(10)], to: viewModel.input)
+        scheduler.start()
+        assert(source).just("alpha")
+    }
     override func tearDown() {
         viewModel = nil
         scheduler = nil

--- a/Example/ExampleTests/ExampleTests.swift
+++ b/Example/ExampleTests/ExampleTests.swift
@@ -104,6 +104,12 @@ class ExampleTests: XCTestCase {
         assert(source).not.complete()
     }
 
+    func testNever() {
+        let source = scheduler.record(source: viewModel.elements)
+        scheduler.bind([], to: viewModel.input)
+        scheduler.start()
+        assert(source).never()
+    }
     override func tearDown() {
         viewModel = nil
         scheduler = nil

--- a/Example/ExampleTests/ExampleTests.swift
+++ b/Example/ExampleTests/ExampleTests.swift
@@ -110,6 +110,12 @@ class ExampleTests: XCTestCase {
         scheduler.start()
         assert(source).never()
     }
+    func testEmpty() {
+        let source = scheduler.record(source: viewModel.elements)
+        scheduler.bind([completed(10)], to: viewModel.input)
+        scheduler.start()
+        assert(source).empty()
+    }
     override func tearDown() {
         viewModel = nil
         scheduler = nil

--- a/RxTestExt.podspec
+++ b/RxTestExt.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "RxTestExt"
-  s.version      = "0.3.0"
+  s.version      = "0.3.1"
   s.summary      = "A collection of operators & tools not found in the core RxTest distribution."
 
   s.description  = <<-DESC

--- a/RxTestExt/Assertion.swift
+++ b/RxTestExt/Assertion.swift
@@ -71,6 +71,14 @@ extension Assertion {
         verify(pass: events.isEmpty,
                message: "never emits, got <\(events.count)> event(s)")
     }
+
+    /// A matcher that succeeds when testable obserevr only recieves a `completed` event.
+    ///
+    /// This is to macth a similar behavior of `Observabel.empty()`
+    public func empty() {
+        verify(pass: events.first?.value.isCompleted ?? false,
+               message: "complete with no other events")
+    }
 }
 // MARK: Next Equality Matchers
 extension Assertion where T: Equatable {

--- a/RxTestExt/Assertion.swift
+++ b/RxTestExt/Assertion.swift
@@ -63,6 +63,15 @@ extension Assertion {
     }
 }
 
+extension Assertion {
+    /// A matcher that succeeds when testable obserevr never recieves an event.
+    ///
+    /// This is to macth a similar behavior of `Observabel.never()`
+    public func never() {
+        verify(pass: events.isEmpty,
+               message: "never emits, got <\(events.count)> event(s)")
+    }
+}
 // MARK: Next Equality Matchers
 extension Assertion where T: Equatable {
     /// A matcher that succeeds when value emitted at a specific index equal a given value.

--- a/RxTestExt/Assertion.swift
+++ b/RxTestExt/Assertion.swift
@@ -27,7 +27,7 @@ public struct Assertion<T> {
         return base.events
     }
 
-	/// A negated version of current assertion
+    /// A negated version of current assertion
     public var not: Assertion<T> {
         return Assertion(base, file: location.file, line: location.line, negated: true)
     }
@@ -112,6 +112,29 @@ extension Assertion where T: Equatable {
     /// - Parameter expectedValue: Expected value.
     public func firstNext(equal expectedValue: T) {
         next(at: 0, equal: expectedValue)
+    }
+
+    /// A matcher that succeeds when testable obserevr only recieves a `next` event and immediately completes.
+    ///
+    /// This is to macth a similar behavior of `Observabel.just()`
+    public func just(_ value: T) {
+        let msg = "get <\(value)> then completes"
+        guard events.count == 2 else {
+            verify(pass: false, message: msg + ", emitted <\(events.count)> event(s)")
+            return
+        }
+        let next = events[0]
+        let complete = events[1]
+        guard complete.value.isCompleted else {
+            verify(pass: false, message: msg + ", didnot complete")
+            return
+        }
+        guard next.time == complete.time else {
+            verify(pass: false, message: msg + ", didnot complete immediately")
+            return
+        }
+        verify(pass: next.value.element == value,
+               message: msg + ", got <\(next.value.element.stringify)>")
     }
 }
 


### PR DESCRIPTION
This PR adds the following matchers, to closely match the behaviour of common RxSwift observables.

- never
- empty
- just

It's mainly motivated by the points raised on [this comment](https://github.com/RxSwiftCommunity/contributors/issues/33#issuecomment-346762567)