### PR TITLE
Add custom value matchers

### DIFF
--- a/Example/ExampleTests/ExampleTests.swift
+++ b/Example/ExampleTests/ExampleTests.swift
@@ -122,6 +122,15 @@ class ExampleTests: XCTestCase {
         scheduler.start()
         assert(source).just("alpha")
     }
+
+    func testMatchFirstNext() {
+        let source = scheduler.record(source: viewModel.elements)
+        scheduler.bind([next(10, "alpha"), completed(10)], to: viewModel.input)
+        scheduler.start()
+        assert(source).firstNext {
+            (!($0?.isEmpty ?? false), "be empty")
+        }
+    }
     override func tearDown() {
         viewModel = nil
         scheduler = nil

--- a/RxTestExt.podspec
+++ b/RxTestExt.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "RxTestExt"
-  s.version      = "0.3.1"
+  s.version      = "0.3.2"
   s.summary      = "A collection of operators & tools not found in the core RxTest distribution."
 
   s.description  = <<-DESC

--- a/RxTestExt/Assertion.swift
+++ b/RxTestExt/Assertion.swift
@@ -80,6 +80,41 @@ extension Assertion {
                message: "complete with no other events")
     }
 }
+// MARK: Next Value Matchers
+extension Assertion {
+    /// A matcher that succeeds when value emitted at a specific index matches a given value.
+    ///
+    /// - Parameters:
+    ///   - index: Event index.
+    ///   - matcher: A closure to evaluate if actual value matches.
+    public func next(at index: Int, match matcher: (T?) -> (Bool, String)) {
+        let nextEvents = events.filter { $0.value.element != nil }
+        guard nextEvents.count > index, index >= 0 else {
+            verify(pass: false,
+                   message: "get enough next events")
+            return
+        }
+        let actualValue = nextEvents[index].value.element
+        let (pass, msg) = matcher(actualValue)
+        verify(pass: pass,
+               message: msg)
+    }
+
+    /// A matcher that succeeds when last emitted next matches a given value.
+    ///
+    ///   - matcher: A closure to evaluate if actual value matches.
+    public func lastNext(match matcher: (T?) -> (Bool, String)) {
+        let nextEvents = events.filter { $0.value.element != nil }
+        next(at: nextEvents.count - 1, match: matcher)
+    }
+
+    /// A matcher that succeeds when first emitted next matches a given value.
+    ///
+    ///   - matcher: A closure to evaluate if actual value matches.
+    public func firstNext(match matcher: (T?) -> (Bool, String)) {
+        next(at: 0, match: matcher)
+    }
+}
 // MARK: Next Equality Matchers
 extension Assertion where T: Equatable {
     /// A matcher that succeeds when value emitted at a specific index equal a given value.


### PR DESCRIPTION
This allows matching `next` events when type is not conforming to `Equatable` protocol